### PR TITLE
Editable name changes

### DIFF
--- a/src/EditablePlayerName.js
+++ b/src/EditablePlayerName.js
@@ -3,6 +3,7 @@ import React, { useCallback, useEffect, useRef, useState } from "react";
 const EditablePlayerName = ({ name, onChange }) => {
   const [editing, setEditing] = useState(false);
   const ref = useRef(null);
+  const originalNameRef = useRef("");
 
   const handleRootClick = useCallback(
     e => {
@@ -27,9 +28,10 @@ const EditablePlayerName = ({ name, onChange }) => {
 
   useEffect(() => {
     if (editing) {
+      originalNameRef.current = name;
       ref.current.focus();
     }
-  }, [editing]);
+  }, [editing]); // eslint-disable-line react-hooks/exhaustive-deps
 
   if (editing) {
     return (
@@ -39,9 +41,14 @@ const EditablePlayerName = ({ name, onChange }) => {
         value={name}
         ref={ref}
         onChange={e => onChange(e.currentTarget.value)}
-        onKeyDown={e =>
-          ["Enter", "Escape"].includes(e.key) && setEditing(false)
-        }
+        onKeyDown={e => {
+          if (["Enter", "Escape"].includes(e.key)) {
+            if (e.key === "Escape") {
+              onChange(originalNameRef.current);
+            }
+            setEditing(false);
+          }
+        }}
       />
     );
   }

--- a/src/EditablePlayerName.js
+++ b/src/EditablePlayerName.js
@@ -14,12 +14,16 @@ const EditablePlayerName = ({ name, onChange }) => {
   );
 
   useEffect(() => {
+    if (!editing) {
+      return;
+    }
+
     document.addEventListener("click", handleRootClick);
 
     return function cleanup() {
       document.removeEventListener("click", handleRootClick);
     };
-  }, [handleRootClick]);
+  }, [handleRootClick, editing]);
 
   if (editing) {
     return (

--- a/src/EditablePlayerName.js
+++ b/src/EditablePlayerName.js
@@ -21,24 +21,23 @@ const EditablePlayerName = ({ name, onChange }) => {
     };
   }, [handleRootClick]);
 
+  if (editing) {
+    return (
+      <input
+        className="form-input"
+        style={{ maxWidth: "150px", margin: "auto" }}
+        value={name}
+        ref={ref}
+        onChange={e => onChange(e.currentTarget.value)}
+        onKeyPress={e =>
+          ["Enter", "Escape"].includes(e.key) && setEditing(false)
+        }
+      />
+    );
+  }
   return (
-    <span style={{ textAlign: "center" }}>
-      {editing ? (
-        <input
-          className="form-input"
-          style={{ maxWidth: "150px", margin: "auto" }}
-          value={name}
-          ref={ref}
-          onChange={e => onChange(e.currentTarget.value)}
-          onKeyPress={e =>
-            ["Enter", "Escape"].includes(e.key) && setEditing(false)
-          }
-        />
-      ) : (
-        <span onClick={e => setEditing(true)}>
-          {name.length >= 1 ? name : "<enter name>"}
-        </span>
-      )}
+    <span onClick={e => setEditing(true)}>
+      {name.length >= 1 ? name : "<enter name>"}
     </span>
   );
 };

--- a/src/EditablePlayerName.js
+++ b/src/EditablePlayerName.js
@@ -39,7 +39,7 @@ const EditablePlayerName = ({ name, onChange }) => {
         value={name}
         ref={ref}
         onChange={e => onChange(e.currentTarget.value)}
-        onKeyPress={e =>
+        onKeyDown={e =>
           ["Enter", "Escape"].includes(e.key) && setEditing(false)
         }
       />

--- a/src/EditablePlayerName.js
+++ b/src/EditablePlayerName.js
@@ -4,7 +4,7 @@ const EditablePlayerName = ({ name, onChange }) => {
   const [editing, setEditing] = useState(false);
   const ref = useRef(null);
 
-  const handleBodyClick = useCallback(
+  const handleRootClick = useCallback(
     e => {
       if (ref.current && !ref.current.contains(e.target)) {
         setEditing(false);
@@ -14,12 +14,12 @@ const EditablePlayerName = ({ name, onChange }) => {
   );
 
   useEffect(() => {
-    document.body.addEventListener("click", handleBodyClick);
+    document.addEventListener("click", handleRootClick);
 
     return function cleanup() {
-      document.body.removeEventListener("click", handleBodyClick);
+      document.removeEventListener("click", handleRootClick);
     };
-  }, [handleBodyClick]);
+  }, [handleRootClick]);
 
   return (
     <span style={{ textAlign: "center" }}>

--- a/src/EditablePlayerName.js
+++ b/src/EditablePlayerName.js
@@ -25,6 +25,12 @@ const EditablePlayerName = ({ name, onChange }) => {
     };
   }, [handleRootClick, editing]);
 
+  useEffect(() => {
+    if (editing) {
+      ref.current.focus();
+    }
+  }, [editing]);
+
   if (editing) {
     return (
       <input


### PR DESCRIPTION
- Put click-outside handler on document rather than body
- Eliminate wrapper span
- Don't add root click handler when not editing
- Focus editable name field when starting editing
- Fix escape key in editable name field
- Cancel name change on escape